### PR TITLE
ibm_power ohai plugin

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,3 +3,4 @@ suites:
   - name: default
     run_list:
       - recipe[ibm-power::default]
+      - recipe[ibm-power-test]

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,5 @@
 source 'https://supermarket.chef.io'
 
+cookbook 'ibm-power-test', path: 'test/cookbooks/ibm-power-test'
+
 metadata

--- a/files/default/plugins/ibm_power.rb
+++ b/files/default/plugins/ibm_power.rb
@@ -1,0 +1,48 @@
+Ohai.plugin(:IbmPower) do
+  provides 'ibm_power'
+  depends 'kernel'
+
+  collect_data(:linux) do
+    ibminfo = Mash.new
+    cpuinfo = Mash.new
+    cpu_number = 0
+    cpu_model = nil
+    current_cpu = nil
+
+    # Only run this on ppc64le
+    if kernel[:machine] == 'ppc64le'
+      File.open('/proc/cpuinfo', 'r').each do |line|
+        case line
+        when /processor\s+:\s(.+)/
+          cpuinfo[Regexp.last_match(1)] = Mash.new
+          current_cpu = Regexp.last_match(1)
+          cpu_number += 1
+        when /^cpu\s+:\s(.+)/
+          cpuinfo[current_cpu]['cpu'] = Regexp.last_match(1)
+          cpu_model = Regexp.last_match(1).match(/(POWER\w+)/)[1].downcase
+        when /^clock\s+:\s(.+)/
+          cpuinfo[current_cpu]['clock'] = Regexp.last_match(1)
+        when /^revision\s+:\s(.+)/
+          cpuinfo[current_cpu]['revision'] = Regexp.last_match(1)
+        when /^timebase\s+:\s(.+)/
+          cpuinfo['timebase'] = Regexp.last_match(1)
+        when /^platform\s+:\s(.+)/
+          cpuinfo['platform'] = Regexp.last_match(1)
+        when /^model\s+:\s(.+)/
+          cpuinfo['machine_model'] = Regexp.last_match(1).strip
+        when /^machine\s+:\s(.+)/
+          cpuinfo['machine'] = Regexp.last_match(1).strip
+        when /^firmware\s+:\s(.+)/
+          cpuinfo['firmware'] = Regexp.last_match(1)
+        when /^MMU\s+:\s(.+)/
+          cpuinfo['mmu'] = Regexp.last_match(1)
+        end
+      end
+      ibminfo[:cpu] = cpuinfo
+      ibminfo[:cpu][:total] = cpu_number
+      ibminfo[:cpu][:cpu_model] = cpu_model
+    end
+
+    ibm_power ibminfo
+  end
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,4 +11,5 @@ version          '2.0.0'
 
 supports         'centos', '~> 7.0'
 
+depends          'ohai'
 depends          'yum'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,8 +16,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ohai_plugin 'ibm_power' do
+  source_file 'plugins/ibm_power.rb'
+end
+
 case node['kernel']['machine']
 when 'ppc64', 'ppc64le'
+
   case node['platform_family']
   when 'rhel'
     remote_file ::File.join(

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -11,6 +11,9 @@ describe 'ibm-power::default' do
             end.converge(described_recipe)
           end
           it do
+            expect(chef_run).to create_ohai_plugin('ibm_power').with(source_file: 'plugins/ibm_power.rb')
+          end
+          it do
             expect(chef_run).to create_remote_file_if_missing(
               ::File.join(
                 Chef::Config[:file_cache_path],
@@ -51,6 +54,9 @@ describe 'ibm-power::default' do
       context 'x86_64' do
         cached(:chef_run) do
           ChefSpec::SoloRunner.new(p).converge(described_recipe)
+        end
+        it do
+          expect(chef_run).to create_ohai_plugin('ibm_power').with(source_file: 'plugins/ibm_power.rb')
         end
         it do
           expect(chef_run).to_not create_remote_file_if_missing(

--- a/test/cookbooks/ibm-power-test/metadata.rb
+++ b/test/cookbooks/ibm-power-test/metadata.rb
@@ -1,0 +1,8 @@
+name             'ibm-power-test'
+maintainer       'Oregon State University'
+maintainer_email 'chef@osuosl.org'
+license          'Apache 2.0'
+description      'Installs/Configures ibm-power-test'
+long_description ''
+version          '0.1.0'
+depends          'ibm-power'

--- a/test/cookbooks/ibm-power-test/recipes/default.rb
+++ b/test/cookbooks/ibm-power-test/recipes/default.rb
@@ -1,0 +1,14 @@
+content_text = ''
+
+return if node['ibm_power']['cpu'].nil?
+
+case node['ibm_power']['cpu']['cpu_model']
+when /power8/
+  content_text = 'power8'
+when /power9/
+  content_text = 'power9'
+end
+
+file '/tmp/ibm-power-test' do
+  content content_text
+end

--- a/test/integration/default/serverspec/server_spec.rb
+++ b/test/integration/default/serverspec/server_spec.rb
@@ -1,3 +1,34 @@
 require 'serverspec'
 
 set :backend, :exec
+
+plugin_directory = '/tmp/kitchen/ohai/plugins'
+
+describe command("ohai -d #{plugin_directory} ibm_power") do
+  its(:exit_status) { should eq 0 }
+  if os[:arch] == 'ppc64le'
+    its(:stdout) { should match(/cpu_model.*power/) }
+  else
+    its(:stdout) { should_not match(/cpu_model.*power/) }
+  end
+end
+
+describe yumrepo('ibm-power-tools') do
+  if os[:arch] == 'ppc64le'
+    it { should exist }
+    it { should be_enabled }
+  else
+    it { should_not exist }
+    it { should_not be_enabled }
+  end
+end
+
+%w(ppc64-diag powerpc-utils).each do |p|
+  describe package(p) do
+    if os[:arch] == 'ppc64le'
+      it { should be_installed }
+    else
+      it { should_not be_installed }
+    end
+  end
+end


### PR DESCRIPTION
This adds a basic ibm_power ohai plugin which parses the cpu information for
POWER8/9 machines. Some of this I will upstream into ohai itself eventually.
This also includes a useful attribute for determining whether the node is power8
or power9 which we need to know now.

I plan to add several other attributes later but this was needed initially. I
couldn't add ohai ChefSpec since we need to be using a newer ChefDK so I'll add
that as a TODO later.