### PR TITLE
Create a separate ohai_plugin recipe

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,4 +3,7 @@ suites:
   - name: default
     run_list:
       - recipe[ibm-power::default]
+  - name: ohai_plugin
+    run_list:
+      - recipe[ibm-power::ohai_plugin]
       - recipe[ibm-power-test]

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,10 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ohai_plugin 'ibm_power' do
-  source_file 'plugins/ibm_power.rb'
-end
-
 case node['kernel']['machine']
 when 'ppc64', 'ppc64le'
 

--- a/recipes/ohai_plugin.rb
+++ b/recipes/ohai_plugin.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook:: ibm-power
+# Recipe:: ohai_plugin
+#
+# Copyright:: 2018, Oregon State University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+ohai_plugin 'ibm_power' do
+  source_file 'plugins/ibm_power.rb'
+end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -11,9 +11,6 @@ describe 'ibm-power::default' do
             end.converge(described_recipe)
           end
           it do
-            expect(chef_run).to create_ohai_plugin('ibm_power').with(source_file: 'plugins/ibm_power.rb')
-          end
-          it do
             expect(chef_run).to create_remote_file_if_missing(
               ::File.join(
                 Chef::Config[:file_cache_path],
@@ -54,9 +51,6 @@ describe 'ibm-power::default' do
       context 'x86_64' do
         cached(:chef_run) do
           ChefSpec::SoloRunner.new(p).converge(described_recipe)
-        end
-        it do
-          expect(chef_run).to create_ohai_plugin('ibm_power').with(source_file: 'plugins/ibm_power.rb')
         end
         it do
           expect(chef_run).to_not create_remote_file_if_missing(

--- a/spec/unit/recipes/ohai_plugin_spec.rb
+++ b/spec/unit/recipes/ohai_plugin_spec.rb
@@ -1,0 +1,17 @@
+require_relative '../../spec_helper'
+
+describe 'ibm-power::ohai_plugin' do
+  ALL_PLATFORMS.each do |p|
+    context "#{p[:platform]} #{p[:version]}" do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(p).converge(described_recipe)
+      end
+      it 'converges successfully' do
+        expect { chef_run }.to_not raise_error
+      end
+      it do
+        expect(chef_run).to create_ohai_plugin('ibm_power').with(source_file: 'plugins/ibm_power.rb')
+      end
+    end
+  end
+end

--- a/test/integration/default/serverspec/server_spec.rb
+++ b/test/integration/default/serverspec/server_spec.rb
@@ -2,17 +2,6 @@ require 'serverspec'
 
 set :backend, :exec
 
-plugin_directory = '/tmp/kitchen/ohai/plugins'
-
-describe command("ohai -d #{plugin_directory} ibm_power") do
-  its(:exit_status) { should eq 0 }
-  if os[:arch] == 'ppc64le'
-    its(:stdout) { should match(/cpu_model.*power/) }
-  else
-    its(:stdout) { should_not match(/cpu_model.*power/) }
-  end
-end
-
 describe yumrepo('ibm-power-tools') do
   if os[:arch] == 'ppc64le'
     it { should exist }

--- a/test/integration/ohai_plugin/serverspec/ohai_plugin_spec.rb
+++ b/test/integration/ohai_plugin/serverspec/ohai_plugin_spec.rb
@@ -1,0 +1,14 @@
+require 'serverspec'
+
+set :backend, :exec
+
+plugin_directory = '/tmp/kitchen/ohai/plugins'
+
+describe command("ohai -d #{plugin_directory} ibm_power") do
+  its(:exit_status) { should eq 0 }
+  if os[:arch] == 'ppc64le'
+    its(:stdout) { should match(/cpu_model.*power/) }
+  else
+    its(:stdout) { should_not match(/cpu_model.*power/) }
+  end
+end


### PR DESCRIPTION
Move the ohai_plugin resource into it's own recipe so that we can use it by
itself as needed.