### PR TITLE
Install ohai plugin at compile time

### DIFF
--- a/recipes/ohai_plugin.rb
+++ b/recipes/ohai_plugin.rb
@@ -17,4 +17,5 @@
 # limitations under the License.
 ohai_plugin 'ibm_power' do
   source_file 'plugins/ibm_power.rb'
+  compile_time true
 end

--- a/spec/unit/recipes/ohai_plugin_spec.rb
+++ b/spec/unit/recipes/ohai_plugin_spec.rb
@@ -10,7 +10,11 @@ describe 'ibm-power::ohai_plugin' do
         expect { chef_run }.to_not raise_error
       end
       it do
-        expect(chef_run).to create_ohai_plugin('ibm_power').with(source_file: 'plugins/ibm_power.rb')
+        expect(chef_run).to create_ohai_plugin('ibm_power')
+          .with(
+            source_file: 'plugins/ibm_power.rb',
+            compile_time: true
+          )
       end
     end
   end


### PR DESCRIPTION
This ensures that we can pull in the attributes when we need it later on.